### PR TITLE
Remove check for method name without "dot" separator

### DIFF
--- a/bitrix24/bitrix24.py
+++ b/bitrix24/bitrix24.py
@@ -150,7 +150,7 @@ class Bitrix24:
         -------
             Returning the REST method response as an array, an object or a scalar
         """
-        if not method or len(method.split(".")) < 2:
+        if not method:
             raise BitrixError("Wrong method name", 400)
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ dir = path.abspath(path.dirname(__file__))
 
 setup(
     name="bitrix24-rest",
-    version="2.0.0",
+    version="2.0.1",
     packages=find_packages(),
     install_requires=[
         "aiohttp",


### PR DESCRIPTION
There are valid methods like "methods" and "scope" that do not have a "dot" separator within their name.
According to the documentation and a "methods" call, there are 5 such methods: ['batch', 'scope', 'methods', 'events', 'profile']

If there's a strong reason for keeping this check, it could instead add a check for manually allowing these five methods, but that seems janky to me.