### PR TITLE
fix pagination

### DIFF
--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -8,18 +8,37 @@ async def test_concurrent_requests(b24):
     with aioresponses() as m:
         m.get(
             "https://example.bitrix24.com/rest/1/123456789/crm.deal.list.json?start=0",
-            payload={"result": [{"ID": 1}], "next": 50, "total": 100},
+            payload={"result": [{"ID": 1}], "next": 50, "total": 82},
             status=200,
             repeat=True,
         )
         m.get(
             "https://example.bitrix24.com/rest/1/123456789/crm.deal.list.json?start=50",
-            payload={"result": [{"ID": 2}], "total": 100},
+            payload={"result": [{"ID": 2}], "total": 82},
             status=200,
             repeat=True,
         )
         res = await b24.callMethod("crm.deal.list")
         assert res == [{"ID": 1}, {"ID": 2}]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_requests_nesting_level(b24):
+    with aioresponses() as m:
+        m.get(
+            "https://example.bitrix24.com/rest/1/123456789/tasks.task.list.json?start=0",
+            payload={"result": {"tasks": [{"ID": 1}]}, "next": 50, "total": 100},
+            status=200,
+            repeat=True,
+        )
+        m.get(
+            "https://example.bitrix24.com/rest/1/123456789/tasks.task.list.json?start=50",
+            payload={"result": {"tasks": [{"ID": 2}]}, "total": 100},
+            status=200,
+            repeat=True,
+        )
+        res = await b24.callMethod("tasks.task.list")
+        assert res == {"tasks": [{"ID": 1}, {"ID": 2}]}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Hello!  unfortunately in the Bitrix24 REST API some answers come with an additional level of nesting.
Example:
```
{
	result: {
		tasks: [
			{
				id: "117",
				...
			}
		]
	}
}
```

and then we get an error:
```
	TypeError: unsupported operand type(s) for +: 'dict' and 'list'
```

also, your tests work correctly if the total is divided by 50 without remainder, but if there is a remainder, then the test will break, the number of elements in the answer will also be incorrect.

These changes fix these errors.